### PR TITLE
Fix mix-format for `.heex` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog].
   calling major-mode. Also includes setting for `indent-tabs-mode` ([#286]).
 * [Formatter scripts](scripts/formatters) will now work on Windows if Emacs
   can find the executable defined in the shebang.
+* `.heex` files are now properly formatted
 
 ### Internal
 * Major internal refactoring has occurred to make it possible to write

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -91,7 +91,8 @@
     (ktlint . ("ktlint" "--log-level=none" "--stdin" "-F" "-"))
     (latexindent . ("latexindent" "--logfile=/dev/null"))
     (mix-format . ("apheleia-from-project-root"
-                   ".formatter.exs" "mix" "format" "-"))
+                   ".formatter.exs" "mix" "format" 
+		   "--stdin-filename" filepath "-"))
     (nixfmt . ("nixfmt"))
     (ocamlformat . ("ocamlformat" "-" "--name" filepath
                     "--enable-outside-detected-project"))


### PR DESCRIPTION
Per the documentation for `mix format`:

```
  • --stdin-filename - path to the file being formatted on stdin. This is
    useful if you are using plugins to support custom filetypes such as .heex.
    Without passing this flag, it is assumed that the code being passed via
    stdin is valid Elixir code. Defaults to "stdin.exs".
```

